### PR TITLE
Added checks to updatenC.sh and docs to INSTALL script

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -44,5 +44,10 @@
     nC.bat -make
 	nC.bat
 
+* Mac Pre-requisites (without these, updatenC.sh will not work)
 
+  XCode command line tools downloaded and installed (http://g.ua/WAAB)
+  Git command line tool downloaded and installed (http://git-scm.com/download/mac)
+                                     (https://help.github.com/articles/set-up-git)
+ 
 

--- a/updatenC.sh
+++ b/updatenC.sh
@@ -12,6 +12,17 @@ export SBML2NEU_SC_DIR=templates/SBML2NEURON
 export NEUROML2_DIR=NeuroML2
 export JNEUROMLJAR_DIR=jNeuroMLJar
 
+if ! type -p svn > /dev/null; then
+    # svn is not installed on the system
+    echo "svn not found on this machine. please install."
+    exit 1
+fi
+
+if ! type -p git > /dev/null; then
+    # git is not installed on the system
+    echo "git not found on this machine. please install."
+    exit 1
+fi
 
 if [ ! -d $NML_EX_DIR ]; then
     svn co https://svn.code.sf.net/p/neuroml/code/trunk/web/NeuroMLFiles/Examples/ $NML_EX_DIR


### PR DESCRIPTION
vanilla mac os x doesn't have svn or git installed.  updatenC.sh now
checks for presence and fails if not present.  INSTALL script now
provides links to go get both
