### PR TITLE
Preserve cell indices when exporting a network to NeuroML.

### DIFF
--- a/src/ucl/physiol/neuroconstruct/project/GeneratedCellPositions.java
+++ b/src/ucl/physiol/neuroconstruct/project/GeneratedCellPositions.java
@@ -563,7 +563,7 @@ public class GeneratedCellPositions
 
                             SimpleXMLElement instanceElement = new SimpleXMLElement(NetworkMLConstants.INSTANCE_ELEMENT);
 
-                            instanceElement.addAttribute(new SimpleXMLAttribute(NetworkMLConstants.INSTANCE_ID_ATTR, i+""));
+                            instanceElement.addAttribute(new SimpleXMLAttribute(NetworkMLConstants.INSTANCE_ID_ATTR, posRec.cellNumber+""));
 
                             if (posRec.getNodeId()!=PositionRecord.NO_NODE_ID)
                             {
@@ -628,7 +628,7 @@ public class GeneratedCellPositions
 
                         SimpleXMLElement instanceElement = new SimpleXMLElement(NetworkMLConstants.INSTANCE_ELEMENT);
 
-                        instanceElement.addAttribute(new SimpleXMLAttribute(NetworkMLConstants.INSTANCE_ID_ATTR, i+""));
+                        instanceElement.addAttribute(new SimpleXMLAttribute(NetworkMLConstants.INSTANCE_ID_ATTR, posRec.cellNumber+""));
 
                         if (posRec.getNodeId()!=PositionRecord.NO_NODE_ID)
                         {


### PR DESCRIPTION
When exporting to NeuroML, the "id" attribute of the <instance/>
element describing a cell position in the exported file is supposed to
correspond to neuroConstruct's "cell number" value for that cell - a
unique identifier of the cell within its group.

The problem here was that the "id" attribute was instead set to the
index indicating the order in which the cell's position record had
been added to the array of generated cell positions; this essentially
results in a permutation of the cell identities within each group if
this index doesn't correspond to the "cell number" value. Usually this
is not a problem, as "cell number"s are generated sequentially as cells
are generated, making the two indices coincide; but it becomes
apparent if manually generating cells in a nontrivial order through
the python scripting interface.